### PR TITLE
Update token_service_test.go

### DIFF
--- a/account/service/token_service_test.go
+++ b/account/service/token_service_test.go
@@ -21,9 +21,15 @@ func TestNewPairFromUser(t *testing.T) {
 	var idExp int64 = 15 * 60
 	var refreshExp int64 = 3 * 24 * 2600
 	priv, _ := ioutil.ReadFile("../rsa_private_test.pem")
-	privKey, _ := jwt.ParseRSAPrivateKeyFromPEM(priv)
+	privKey, err := jwt.ParseRSAPrivateKeyFromPEM(priv)
+	if err != nil {
+		privKey, _ = generatePrivateKey(2048)
+	}
 	pub, _ := ioutil.ReadFile("../rsa_public_test.pem")
-	pubKey, _ := jwt.ParseRSAPublicKeyFromPEM(pub)
+	pubKey, err := jwt.ParseRSAPublicKeyFromPEM(pub)
+	if err != nil {
+		pubKey = &privKey.PublicKey
+	}
 	secret := "anotsorandomtestsecret"
 
 	mockTokenRepository := new(mocks.MockTokenRepository)
@@ -235,9 +241,15 @@ func TestValidateIDToken(t *testing.T) {
 	var idExp int64 = 15 * 60
 
 	priv, _ := ioutil.ReadFile("../rsa_private_test.pem")
-	privKey, _ := jwt.ParseRSAPrivateKeyFromPEM(priv)
+	privKey, err := jwt.ParseRSAPrivateKeyFromPEM(priv)
+	if err != nil {
+		privKey, _ = generatePrivateKey(2048)
+	}
 	pub, _ := ioutil.ReadFile("../rsa_public_test.pem")
-	pubKey, _ := jwt.ParseRSAPublicKeyFromPEM(pub)
+	pubKey, err := jwt.ParseRSAPublicKeyFromPEM(pub)
+	if err != nil {
+		pubKey = &privKey.PublicKey
+	}
 
 	// instantiate a common token service to be used by all tests
 	tokenService := NewTokenService(&TSConfig{


### PR DESCRIPTION
when there testing on github without .pem file, loading the key here make the error, so I create a dummy private key and public key for testing. And it passed even when we failed to retrieve key-pair